### PR TITLE
Visibility and settings file fixes

### DIFF
--- a/Publisher.cs
+++ b/Publisher.cs
@@ -101,7 +101,7 @@ internal class Publisher
         Console.WriteLine($"{issue.CreatedAt:yy/MM/dd HH:mm:ss} - {text}");
         if (!_settings.Debug)
         {
-            Status status = await _mastodon.PublishStatus(text, Visibility.Unlisted);
+            Status status = await _mastodon.PublishStatus(text, _settings.Visibility);
             Console.WriteLine($"    Status published to Mastodon. ID: {status.Url}");
             Thread.Sleep(1000);
         }

--- a/appsettings.json
+++ b/appsettings.json
@@ -9,6 +9,7 @@
   "GitHubLatestIssueNumber": 0,
   "MastodonServer": "",
   "MastodonAccessToken": "",
+  "Visibility": "Unlisted",
   "SleepSeconds":  120,
   "Debug": true
 }


### PR DESCRIPTION
- Add visibility enum value to settings file.
- Ensure visibility is collected as enum by json when reading the file.
- Use proper full path for settings file, where directory is the same as executable.