### PR TITLE
Fix bug causing some issues/PRs to get skipped

### DIFF
--- a/Publisher.cs
+++ b/Publisher.cs
@@ -90,7 +90,7 @@ internal class Publisher
         Issue? lastPublishedIssue = GetLastPublishedIssue(latestIssues);
 
         return latestIssues
-            .Where(i => i.CreatedAt > lastPublishedIssue.CreatedAt && i.Number > lastPublishedIssue.Number)
+            .Where(i => i.Number > lastPublishedIssue.Number)
             .OrderBy(i => i.Number); // Re-sorted ascending so they get published in order of creation
     }
 


### PR DESCRIPTION
The creation where filter is not necessary. Sometimes we transfer issues from other repos to runtime, and those issues were created at a time that does not match the filter, but the system creates it with the next issue number available. That means that if the item was very old, but freshly transferred, it doesn't show up in the returned list.

Removing the filter does the trick. We only need to know issue/PR number and sort.