### PR TITLE
Use EventLog on Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ obj/
 bin/
 .vs/
 .vscode/
+**/*.binlog

--- a/Log.Unix.cs
+++ b/Log.Unix.cs
@@ -1,0 +1,20 @@
+﻿using System;
+
+namespace MastodonGitHubBot;
+
+internal partial class Log : IDisposable
+{
+    public Log()
+    {
+    }
+
+    public void Dispose()
+    {
+    }
+
+    private void WriteInternal(string message, LogType type)
+    {
+        Validate(message, type);
+        ConsoleWrite(message, type);
+    }
+}

--- a/Log.Windows.cs
+++ b/Log.Windows.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Diagnostics;
+
+namespace MastodonGitHubBot;
+
+internal partial class Log : IDisposable
+{
+    private const string LogName = "MastodonGitHubBot";
+    private const string LogSource = LogName;
+    private const string LogMachineName = ".";
+
+    private readonly EventLog _eventLog;
+
+    public Log()
+    {
+        // Throws if non-elevated due to attempt to read "Security" source.
+        if (!EventLog.SourceExists(LogSource, LogMachineName))
+        {
+            EventLog.CreateEventSource(new EventSourceCreationData(LogSource, LogName) { MachineName = LogMachineName });
+        }
+        _eventLog = new EventLog(LogName, LogMachineName, LogSource);
+    }
+
+    public void Dispose() => _eventLog.Dispose();
+
+    private void WriteInternal(string message, LogType type)
+    {
+        Validate(message, type);
+        ConsoleWrite(message, type);
+        // Throws if non-elevated due to attempt to read "Security" source.
+        _eventLog.WriteEntry(message, (EventLogEntryType)type);
+    }
+}

--- a/Log.cs
+++ b/Log.cs
@@ -1,0 +1,48 @@
+﻿using System;
+
+namespace MastodonGitHubBot;
+
+internal partial class Log : IDisposable
+{
+    // Intermediate enum to avoid exposing System.Diagnostics.EventLogEntryType to non-Windows platforms.
+    internal enum LogType
+    {
+        Error = 1,
+        Warning = 2,
+        Information = 4,
+        Success = 8,
+        Failure = 16,
+    }
+
+    internal void WriteInfo(string message) => WriteInternal(message, LogType.Information);
+    internal void WriteWarning(string message) => WriteInternal(message, LogType.Warning);
+    internal void WriteError(string message) => WriteInternal(message, LogType.Error);
+    internal void WriteFailure(string message) => WriteInternal(message, LogType.Failure);
+    internal void WriteSuccess(string message) => WriteInternal(message, LogType.Success);
+
+    private static void ConsoleWrite(string message, LogType type)
+    {
+        ConsoleColor originalColor = Console.ForegroundColor;
+        ConsoleColor newColor = type switch
+        {
+            LogType.Information => ConsoleColor.White,
+            LogType.Warning => ConsoleColor.Yellow,
+            LogType.Error => ConsoleColor.Red,
+            LogType.Success => ConsoleColor.Green,
+            LogType.Failure => ConsoleColor.DarkRed,
+            _ => throw new ArgumentOutOfRangeException(nameof(type))
+        };
+        Console.ForegroundColor = newColor;
+        Console.WriteLine(message);
+        Console.ForegroundColor = originalColor;
+    }
+
+    private static void Validate(string message, LogType type)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(message);
+        if (!Enum.IsDefined(type))
+        {
+            throw new ArgumentOutOfRangeException(nameof(type));
+        }
+    }
+}

--- a/Mastodon.cs
+++ b/Mastodon.cs
@@ -8,20 +8,20 @@ namespace MastodonGitHubBot;
 
 internal static class Mastodon
 {
-    public static async Task<MastodonClient> GetClientAsync(Settings settings, HttpClient sharedHttpClient)
+    public static async Task<MastodonClient> GetClientAsync(Log log, Settings settings, HttpClient sharedHttpClient)
     {
-        string accessToken = await GetAccessTokenAsync(settings, sharedHttpClient);
+        string accessToken = await GetAccessTokenAsync(log, settings, sharedHttpClient);
         return new MastodonClient(instance: settings.MastodonServer, accessToken, sharedHttpClient);
     }
 
-    private static async Task<string> GetAccessTokenAsync(Settings settings, HttpClient sharedHttpClient)
+    private static async Task<string> GetAccessTokenAsync(Log log, Settings settings, HttpClient sharedHttpClient)
     {
         if (string.IsNullOrWhiteSpace(settings.MastodonAccessToken))
         {
             AuthenticationClient authClient = new(instance: settings.MastodonServer, sharedHttpClient);
             await authClient.CreateApp(appName: settings.AppName, Scope.Write);
 
-            string authCode = GetMastodonOAuthCode(authClient);
+            string authCode = GetMastodonOAuthCode(log, authClient);
 
             Auth auth = await authClient.ConnectWithCode(authCode);
 
@@ -31,10 +31,10 @@ internal static class Mastodon
         return settings.MastodonAccessToken;
     }
 
-    private static string GetMastodonOAuthCode(AuthenticationClient authClient)
+    private static string GetMastodonOAuthCode(Log log, AuthenticationClient authClient)
     {
         string url = authClient.OAuthUrl();
-        Console.WriteLine($"Go to the authorization page: {url}");
+        log.WriteWarning($"Go to the authorization page '{url}' then paste the authentication code in the console.");
         Console.Write("Paste the authentication code: ");
         string authCode = Console.ReadLine() ?? throw new NullReferenceException(nameof(authCode));
         ArgumentException.ThrowIfNullOrEmpty(authCode);

--- a/MastodonGitHubBot.csproj
+++ b/MastodonGitHubBot.csproj
@@ -1,21 +1,32 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
-    <ImplicitUsings>disable</ImplicitUsings>
-    <Nullable>enable</Nullable>
-  </PropertyGroup>
+    <PropertyGroup>
+        <OutputType>Exe</OutputType>
+        <TargetFrameworks>net7.0-windows;net7.0</TargetFrameworks>
+        <ImplicitUsings>disable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+    </PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Mastonet" Version="2.0.0-preview-2022-11-18" />
-    <PackageReference Include="Octokit" Version="4.0.1" />
-  </ItemGroup>
+    <ItemGroup Condition="'$(TargetFramework)' == 'net7.0-windows'">
+        <Compile Remove="*.Unix.cs" />
+        <None Include="*.Unix.cs" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)" />
+    </ItemGroup>
 
-  <ItemGroup>
-    <None Update="appsettings.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-  </ItemGroup>
+    <ItemGroup Condition="'$(TargetFramework)' != 'net7.0-windows'">
+        <Compile Remove="*.Windows.cs" />
+        <None Include="*.Windows.cs" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Mastonet" Version="2.3.0" />
+        <PackageReference Include="Octokit" Version="5.0.2" />
+        <PackageReference Include="System.Diagnostics.EventLog" Version="7.0.0" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <None Update="appsettings.json">
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        </None>
+    </ItemGroup>
 
 </Project>

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Prerequisites:
 - Click on "Generate a new client secret", then copy the generated secret, you'll need it later.
 - Clone, build and run this project.
 - Follow the instructions to generate the access tokens for GitHub and Mastodon. They will get stored automatically under `bin\<Configuration>\net7.0\appsettings.json`.
+- On Windows, run the tool as administrator to ensure event logging works.
 
 Note: The `Debug` value in `appsettings.json` is set to `true` by default, meaning it will initially only print to console and won't publish toots to Mastodon. You need to set it to `false` to start tooting.
 


### PR DESCRIPTION
This tool is normally run on Windows as a Scheduled Task, meaning the console window is not normally visible. This means that Event Viewer is the most appropriate way to debug the tool's behavior.

.NET allows the creation of Windows Events via System.Diagnostics.EventLog APIs. Naturally, this aassembly is only available on Windows. Unfortunately, it can only be executed as an administrator since Windows Vista, due to the internal requirement of verifying if the event should exist under the "Security" log category, which is only readable as an administrator.

This PR adds the following changes:
- Creates the new event log source and logname if it does not yet exist in the current machine. This change now requires the tool to run as administrator.
- Splits the Log class into partial implementations so the tool can work on both Windows and non-Windows apps (no event logging on the latter).
- Prevents CA1416 (API called on unsupported platform) inside the non-Windows Log partial implementation by using an intermediate enum.
- Captures any global exception, logs an event, then throws.
- Updates dependencies.
- Ignores binlog files with .gitignore.